### PR TITLE
hotfix: Disentangle Buttons and cards

### DIFF
--- a/src/components/items/AnnouncementItem.tsx
+++ b/src/components/items/AnnouncementItem.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Text, View } from 'react-native';
+import { Pressable, Text, View } from 'react-native';
 
-import { Button } from '../common';
 import { useRouter } from 'expo-router';
 
 import { setSelectedAnnouncement } from '@/stores/announcementStores';
@@ -30,7 +29,7 @@ export const AnnouncementItem: React.FC<Announcement> = ({
   };
 
   return (
-    <Button
+    <Pressable
       style={containerStyles.card}
       onPress={() => {
         setSelectedAnnouncement(createObj());
@@ -41,7 +40,7 @@ export const AnnouncementItem: React.FC<Announcement> = ({
         <Text style={textStyles.listTitle}>{title}</Text>
         <Text style={textStyles.detail}>{info}</Text>
       </View>
-    </Button>
+    </Pressable>
   );
 };
 export default AnnouncementItem;

--- a/src/components/items/CatalogItem.tsx
+++ b/src/components/items/CatalogItem.tsx
@@ -1,8 +1,8 @@
 // CatalogItem.js
 import React, { useEffect, useState } from 'react';
 import { Image, Text, View } from 'react-native';
+import { Pressable } from 'react-native';
 
-import { Button } from '../common';
 import { useRouter } from 'expo-router';
 
 import DatabaseService from '@/services/DatabaseService';
@@ -40,7 +40,7 @@ export const CatalogItem: React.FC<CatalogEntry> = ({
   };
 
   return (
-    <Button
+    <Pressable
       style={containerStyles.card}
       onPress={() => {
         createObj();
@@ -62,7 +62,7 @@ export const CatalogItem: React.FC<CatalogEntry> = ({
       <Text style={[textStyles.detail, { alignSelf: 'center' }]}>
         {cat.descShort}
       </Text>
-    </Button>
+    </Pressable>
   );
 };
 export default CatalogItem;

--- a/src/components/items/StationItem.tsx
+++ b/src/components/items/StationItem.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
-import { Image, Text, View } from 'react-native';
+import { Image, Pressable, Text, View } from 'react-native';
 import { Checkbox } from 'react-native-paper';
 
-import { Button } from '../common';
 import { useFocusEffect, useRouter } from 'expo-router';
 
 import DatabaseService from '@/services/DatabaseService';
@@ -48,7 +47,7 @@ export const StationItem: React.FC<Station> = ({
   });
 
   return (
-    <Button
+    <Pressable
       style={containerStyles.card}
       onPress={() => {
         createObj();
@@ -84,7 +83,7 @@ export const StationItem: React.FC<Station> = ({
           </Text>
         </View>
       </View>
-    </Button>
+    </Pressable>
   );
 };
 export default StationItem;

--- a/src/styles/containers.js
+++ b/src/styles/containers.js
@@ -48,6 +48,7 @@ const containerStyles = StyleSheet.create({
     flexDirection: 'column',
     alignSelf: 'center',
     width: vw * 95,
+    height: 'auto',
     padding: vw * 5,
     backgroundColor: '#fff',
     borderRadius: vw * 4,


### PR DESCRIPTION
Cards should be using some generic Pressable/Touchable, and definitely NOT the Button component (since that wraps children in Text, and has a particular style applied). This small hotfix will enable work to progress on properly styling and using the Button component, but eventually Cards should be extracted as their own component.