### PR TITLE
Buttons

### DIFF
--- a/src/app/(app)/(tabs)/announcements.tsx
+++ b/src/app/(app)/(tabs)/announcements.tsx
@@ -45,11 +45,8 @@ const Announcements = () => {
         ))}
       </ScrollView>
       {isAdmin ? (
-        <Button
-          style={buttonStyles.bigButton}
-          onPress={() => router.push('/announcements/create-ann')}
-        >
-          <Text style={textStyles.bigButtonText}> Create Announcement</Text>
+        <Button onPress={() => router.push('/announcements/create-ann')}>
+          Create Announcement
         </Button>
       ) : null}
     </SafeAreaView>

--- a/src/app/(app)/(tabs)/catalog.tsx
+++ b/src/app/(app)/(tabs)/catalog.tsx
@@ -36,11 +36,8 @@ const Catalog = () => {
         ))}
       </ScrollView>
       {adminStatus ? (
-        <Button
-          style={buttonStyles.bigButton}
-          onPress={() => router.push('/catalog/create-entry')}
-        >
-          <Text style={textStyles.bigButtonText}> Create Entry</Text>
+        <Button onPress={() => router.push('/catalog/create-entry')}>
+          Create Entry
         </Button>
       ) : null}
     </SafeAreaView>

--- a/src/app/(app)/(tabs)/index.tsx
+++ b/src/app/(app)/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { View } from 'react-native';
+import { Text, View } from 'react-native';
 
 import { useFocusEffect, useRouter } from 'expo-router';
 
@@ -49,12 +49,15 @@ const HomeScreen = () => {
               filter === range && buttonStyles.activeButton,
             ]}
             onPress={() => setFilter(range)}
-            textStyle={[
-              textStyles.buttonText,
-              filter === range && textStyles.activeText,
-            ]}
           >
-            {range === '365' ? '1Y' : range === 'all' ? 'All' : `${range}D`}
+            <Text
+              style={[
+                textStyles.buttonText,
+                filter === range && textStyles.activeText,
+              ]}
+            >
+              {range === '365' ? '1Y' : range === 'all' ? 'All' : `${range}D`}
+            </Text>
           </Button>
         ))}
       </View>
@@ -78,9 +81,8 @@ const HomeScreen = () => {
       <Button
         style={buttonStyles.reportButton}
         onPress={() => router.push('/sighting/create-sighting')}
-        textStyle={textStyles.buttonText}
       >
-        Report
+        <Text style={textStyles.buttonText}>Report</Text>
       </Button>
     </View>
   );

--- a/src/app/(app)/(tabs)/settings.tsx
+++ b/src/app/(app)/(tabs)/settings.tsx
@@ -160,19 +160,13 @@ const Settings = () => {
         </View>
       </ScrollView>
       {isAdmin ? (
-        <Button
-          style={buttonStyles.bigButton}
-          onPress={() => router.push('/settings/manage_users')}
-        >
-          <Text style={textStyles.bigButtonText}>Manage Users</Text>
+        <Button onPress={() => router.push('/settings/manage_users')}>
+          Manage Users
         </Button>
       ) : null}
       {isAdmin ? (
-        <Button
-          style={buttonStyles.bigButton}
-          onPress={() => router.push('/settings/manage_whitelist')}
-        >
-          <Text style={textStyles.bigButtonText}>Manage Whitelist</Text>
+        <Button onPress={() => router.push('/settings/manage_whitelist')}>
+          Manage Whitelist
         </Button>
       ) : null}
     </SafeAreaView>

--- a/src/app/(app)/(tabs)/stations.tsx
+++ b/src/app/(app)/(tabs)/stations.tsx
@@ -87,11 +87,8 @@ const Stations = () => {
           />
         ))}
       </ScrollView>
-      <Button
-        style={buttonStyles.bigButton}
-        onPress={() => router.push('/stations/create-station')}
-      >
-        <Text style={textStyles.bigButtonText}> Create Station</Text>
+      <Button onPress={() => router.push('/stations/create-station')}>
+        Create Station
       </Button>
     </SafeAreaView>
   );

--- a/src/app/(app)/(tabs)/stations.tsx
+++ b/src/app/(app)/(tabs)/stations.tsx
@@ -55,16 +55,19 @@ const Stations = () => {
               filter === label && buttonStyles.activeButton,
             ]}
             onPress={() => setFilter(label as typeof filter)}
-            textStyle={[
-              textStyles.buttonText,
-              filter === label && textStyles.activeText,
-            ]}
           >
-            {label === 'All'
-              ? 'All'
-              : label === 'Stocked'
-                ? 'Stocked'
-                : 'Unstocked'}
+            <Text
+              style={[
+                textStyles.buttonText,
+                filter === label && textStyles.activeText,
+              ]}
+            >
+              {label === 'All'
+                ? 'All'
+                : label === 'Stocked'
+                  ? 'Stocked'
+                  : 'Unstocked'}
+            </Text>
           </Button>
         ))}
       </View>

--- a/src/app/(app)/announcements/create-ann.tsx
+++ b/src/app/(app)/announcements/create-ann.tsx
@@ -60,13 +60,12 @@ const CreateAnn = () => {
         />
       </ScrollView>
       <Button
-        style={buttonStyles.bigButton}
         onPress={() => {
           createObj();
           void database.handleAnnouncementCreate(photos, setVisible, router);
         }}
       >
-        <Text style={textStyles.bigButtonText}> Create Announcement</Text>
+        Create Announcement
       </Button>
     </SafeAreaView>
   );

--- a/src/app/(app)/announcements/edit-ann.tsx
+++ b/src/app/(app)/announcements/edit-ann.tsx
@@ -79,7 +79,6 @@ const EditAnn = () => {
         />
       </ScrollView>
       <Button
-        style={buttonStyles.bigButton}
         onPress={() => {
           createObj();
           void database.handleAnnouncementSave(
@@ -90,13 +89,13 @@ const EditAnn = () => {
           );
         }}
       >
-        <Text style={textStyles.bigButtonText}> Save Announcement</Text>
+        Save Announcement
       </Button>
       <Button
         style={buttonStyles.bigDeleteButton}
         onPress={() => database.deleteAnnouncement(ann.id, router, setVisible)}
       >
-        <Text style={textStyles.bigButtonText}>Delete Announcement</Text>
+        Delete Announcement
       </Button>
     </SafeAreaView>
   );

--- a/src/app/(app)/announcements/view-ann.tsx
+++ b/src/app/(app)/announcements/view-ann.tsx
@@ -29,11 +29,8 @@ const ViewAnn = () => {
         <AnnouncementEntry />
       </ScrollView>
       {isAdmin ? (
-        <Button
-          style={buttonStyles.bigButton}
-          onPress={() => router.push('/announcements/edit-ann')}
-        >
-          <Text style={textStyles.bigButtonText}> Edit Announcement</Text>
+        <Button onPress={() => router.push('/announcements/edit-ann')}>
+          Edit Announcement
         </Button>
       ) : null}
     </SafeAreaView>

--- a/src/app/(app)/catalog/create-entry.tsx
+++ b/src/app/(app)/catalog/create-entry.tsx
@@ -197,13 +197,12 @@ const CreateEntry = () => {
         )}
       />
       <Button
-        style={buttonStyles.bigButton}
         onPress={() => {
           createObj();
           void database.handleCatalogCreate(photos, setVisible, router);
         }}
       >
-        <Text style={textStyles.bigButtonText}> Create Entry</Text>
+        Create Entry
       </Button>
     </SafeAreaView>
   );

--- a/src/app/(app)/catalog/edit-entry.tsx
+++ b/src/app/(app)/catalog/edit-entry.tsx
@@ -228,7 +228,6 @@ const EditEntry = () => {
         )}
       />
       <Button
-        style={buttonStyles.bigButton}
         onPress={() => {
           createObj();
           void database.handleCatalogSave(
@@ -240,7 +239,7 @@ const EditEntry = () => {
           );
         }}
       >
-        <Text style={textStyles.bigButtonText}> Save Entry</Text>
+        Save Entry
       </Button>
       <Button
         style={buttonStyles.bigDeleteButton}
@@ -248,7 +247,7 @@ const EditEntry = () => {
           database.deleteCatalogEntry(entry.id, setVisible, router)
         }
       >
-        <Text style={textStyles.bigButtonText}>Delete Catalog Entry</Text>
+        Delete Catalog Entry
       </Button>
     </SafeAreaView>
   );

--- a/src/app/(app)/catalog/view-entry.tsx
+++ b/src/app/(app)/catalog/view-entry.tsx
@@ -30,11 +30,8 @@ const ViewEntry = () => {
         <CatalogEntryElement />
       </ScrollView>
       {isAdmin ? (
-        <Button
-          style={buttonStyles.bigButton}
-          onPress={() => router.push('/catalog/edit-entry')}
-        >
-          <Text style={textStyles.bigButtonText}> Edit Entry</Text>
+        <Button onPress={() => router.push('/catalog/edit-entry')}>
+          Edit Entry
         </Button>
       ) : null}
     </SafeAreaView>

--- a/src/app/(app)/sighting/create-sighting.tsx
+++ b/src/app/(app)/sighting/create-sighting.tsx
@@ -91,13 +91,12 @@ const SightingCreateScreen = () => {
       />
 
       <Button
-        style={buttonStyles.bigButton}
         onPress={() => {
           createObj();
           void database.createSighting(photos, setVisible, router);
         }}
       >
-        <Text style={textStyles.bigButtonText}>Create Report</Text>
+        Create Report
       </Button>
     </SafeAreaView>
   );

--- a/src/app/(app)/sighting/edit-sighting.tsx
+++ b/src/app/(app)/sighting/edit-sighting.tsx
@@ -117,7 +117,6 @@ const SightingEditScreen = () => {
         )}
       />
       <Button
-        style={buttonStyles.bigButton}
         onPress={() => {
           createObj();
           void database.saveSighting(
@@ -129,13 +128,13 @@ const SightingEditScreen = () => {
           );
         }}
       >
-        <Text style={textStyles.bigButtonText}>Save Report</Text>
+        Save Report
       </Button>
       <Button
         style={buttonStyles.bigDeleteButton}
         onPress={() => database.deleteSighting(sighting.id, setVisible, router)}
       >
-        <Text style={textStyles.bigButtonText}>Delete Report</Text>
+        Delete Report
       </Button>
     </SafeAreaView>
   );

--- a/src/app/(app)/sighting/view-sighting.tsx
+++ b/src/app/(app)/sighting/view-sighting.tsx
@@ -30,12 +30,7 @@ const SightingScreen = () => {
         <SightingEntry />
       </ScrollView>
       {isAuthorized && (
-        <Button
-          style={buttonStyles.bigButton}
-          onPress={() => router.push('./edit-sighting')}
-        >
-          <Text style={textStyles.bigButtonText}>Edit</Text>
-        </Button>
+        <Button onPress={() => router.push('./edit-sighting')}>Edit</Button>
       )}
     </SafeAreaView>
   );

--- a/src/app/(auth)/whitelist.tsx
+++ b/src/app/(auth)/whitelist.tsx
@@ -106,12 +106,11 @@ const Whitelist = () => {
         </View>
       </ScrollView>
       <Button
-        style={buttonStyles.bigButton}
         onPress={() =>
           database.submitWhitelist(createObj(), setVisible, router)
         }
       >
-        <Text style={textStyles.bigButtonText}>Submit Application</Text>
+        Submit Application
       </Button>
     </SafeAreaView>
   );

--- a/src/components/common/buttons/Button.tsx
+++ b/src/components/common/buttons/Button.tsx
@@ -1,54 +1,27 @@
-import {
-  StyleProp,
-  Text,
-  TextStyle,
-  TouchableOpacity,
-  TouchableOpacityProps,
-  ViewStyle,
-} from 'react-native';
+import { Text, TouchableOpacity, TouchableOpacityProps } from 'react-native';
 
 import { buttonStyles, textStyles } from '@/styles';
 
-type ButtonProps = React.PropsWithoutRef<TouchableOpacityProps> & {
-  children?: React.ReactNode;
-  style?: StyleProp<ViewStyle>;
-  textStyle?: StyleProp<TextStyle>;
-};
-
-export const Button: React.FC<ButtonProps> = ({
+export const Button = ({
   children,
   style,
-  textStyle,
   ...props
-}) => {
-  const style_: StyleProp<ViewStyle> = [buttonStyles.button, style];
-  const textStyle_: StyleProp<TextStyle> = [
-    textStyles.smallButtonText,
-    textStyle,
-  ];
-
+}: TouchableOpacityProps) => {
   return (
-    <TouchableOpacity style={style_} {...props}>
-      <Text style={textStyle_}>{children}</Text>
+    <TouchableOpacity style={[buttonStyles.bigButton, style]} {...props}>
+      <Text style={textStyles.bigButtonText}>{children}</Text>
     </TouchableOpacity>
   );
 };
 
-export const ImageButton: React.FC<ButtonProps> = ({
+export const ImageButton = ({
   children,
   style,
-  textStyle,
   ...props
-}) => {
-  const style_: StyleProp<ViewStyle> = [buttonStyles.imageButton, style];
-  const textStyle_: StyleProp<TextStyle> = [
-    textStyles.smallButtonText,
-    textStyle,
-  ];
-
+}: TouchableOpacityProps) => {
   return (
-    <TouchableOpacity style={style_} {...props}>
-      <Text style={textStyle_}>{children}</Text>
+    <TouchableOpacity style={[buttonStyles.imageButton, style]} {...props}>
+      <Text style={textStyles.smallButtonText}>{children}</Text>
     </TouchableOpacity>
   );
 };

--- a/src/components/entries/CatalogEntryElement.tsx
+++ b/src/components/entries/CatalogEntryElement.tsx
@@ -66,14 +66,9 @@ const CatalogEntryElement: React.FC = () => {
           />
         ))}
       </MapView>
-      <Button
-        style={buttonStyles.bigButton}
-        onPress={() => setShowDetails(!showDetails)}
-      >
-        <Text style={textStyles.bigButtonText}>
-          {' '}
-          {showDetails ? 'Show less details' : 'Show more details'}
-        </Text>
+      <Button onPress={() => setShowDetails(!showDetails)}>
+        {' '}
+        {showDetails ? 'Show less details' : 'Show more details'}
       </Button>
       {showDetails ? (
         <>

--- a/src/forms/SightingReport.tsx
+++ b/src/forms/SightingReport.tsx
@@ -176,14 +176,9 @@ export const SightingReportForm: React.FC<ReportFormProps> = ({
         </View>
         {onDelete ? <Button onPress={onDelete}>Delete</Button> : null}
       </ScrollView>
-      <Button
-        style={buttonStyles.bigButton}
-        onPress={handleSubmit(submitHandler, onInvalid)}
-      >
-        <Text style={textStyles.bigButtonText}>
-          {type === 'create' ? 'Submit Sighting' : null}
-          {type === 'edit' ? 'Save' : null}
-        </Text>
+      <Button onPress={handleSubmit(submitHandler, onInvalid)}>
+        {type === 'create' ? 'Submit Sighting' : null}
+        {type === 'edit' ? 'Save' : null}
       </Button>
       <Errorbar error={error} onDismiss={() => setError('')} />
     </>


### PR DESCRIPTION
Set the styles of the basic button correctly, and subsequently remove all the redundant declarations of style (along with the redundant Text components, as Button automatically wraps children strings in Text).

Note that the `textStyle` prop has been removed from `Button`. This was done because it was infrequently used, and fairly non-standard (and thus possibly confusing). To replace this pattern, use the [nested text](https://reactnative.dev/docs/text#nested-text) feature of React Native's `Text`:

```js
<Button>
  <Text style={styles.nonStandardStyle}>
    Sample text
  </Text>
</Button>
```